### PR TITLE
Order LoggingLevel from least to most severe

### DIFF
--- a/src/MCP/Types.hs
+++ b/src/MCP/Types.hs
@@ -148,8 +148,8 @@ newtype ProgressToken = ProgressToken Value
     deriving newtype (ToJSON, FromJSON)
 
 -- | The severity of a log message
-data LoggingLevel = Alert | Critical | Debug | Emergency | Error | Info | Notice | Warning
-    deriving stock (Show, Eq, Generic)
+data LoggingLevel = Debug | Info | Notice | Warning | Error | Critical | Alert | Emergency
+    deriving stock (Show, Eq, Generic, Ord {- ^ Order from least to most severe -})
 
 instance ToJSON LoggingLevel where
     toJSON Alert = "alert"


### PR DESCRIPTION
Hello @Tritlo 
thank you for creating this library!
I'd find it useful in my project if I could order the LoggingLevel using Ord instance based on severity.
See https://modelcontextprotocol.io/specification/2025-11-25/server/utilities/logging#log-levels