### PR TITLE
fix(http): plumb per-request auth user into handler state

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,6 +35,7 @@ RUN --mount=type=cache,id=apt-cache-mcp,target=/var/cache/apt \
       curl \
       ca-certificates \
       locales \
+      pkg-config \
       build-essential \
       libffi-dev \
       libgmp-dev \

--- a/Dockerfile
+++ b/Dockerfile
@@ -76,7 +76,7 @@ RUN curl -fsSL https://get-ghcup.haskell.org -o /tmp/get-ghcup.sh && \
 # We copy only the cabal files, since these won't change usually. This lets us avoid
 # rebuilding the dependencies all the time.
 COPY --parents --chown=${UID}:${GID} */*.cabal */*/*.cabal /app/
-COPY --chown=${UID}:${GID} cabal.project /app/cabal.project
+COPY --chown=${UID}:${GID} cabal.project cabal.project.freeze /app/
 
 WORKDIR /app
 # Using the cabal files, we can build the dependencies

--- a/mcp-server/src/MCP/Server/Common.hs
+++ b/mcp-server/src/MCP/Server/Common.hs
@@ -38,6 +38,9 @@ module MCP.Server.Common (
     MCPServerState (..),
     initMCPServerState,
 
+    -- * Per-request authentication
+    getCurrentUser,
+
     -- * Type families
     MCPHandlerState,
     MCPHandlerUser,
@@ -300,7 +303,23 @@ initMCPServerState ::
     ProcessHandlers ->
     MCPServerState
 initMCPServerState init_state handler_init handler_finalize =
-    MCPServerState False init_state handler_init handler_finalize Nothing (Just Warning) IM.empty 0
+    MCPServerState False init_state Nothing handler_init handler_finalize Nothing (Just Warning) IM.empty 0
+
+{- | Read the authenticated user associated with the request currently being
+processed.
+
+This reflects the @servant-auth@ result attached to the in-flight HTTP request
+(JWT transport) and is set per request before each handler runs.  It is the
+recommended way to derive identity inside a handler — unlike the one-shot
+'mcp_handler_init' hook, which only fires on the first @initialize@ call to
+the server-process-wide singleton state and is unsafe for multi-tenant
+deployments.
+
+Returns 'Nothing' under transports that do not perform per-request auth
+(stdio, @simpleHttpApp@).
+-}
+getCurrentUser :: MCPServerT (Maybe MCPHandlerUser)
+getCurrentUser = gets mcp_current_user
 
 {- | Type family used to configure the handler state threaded through 'MCPServerT'.
 Users must provide a type instance before using the MCP server, e.g.
@@ -324,6 +343,11 @@ data MCPServerState = MCPServerState
     -- ^ Whether initialize has been called
     , mcp_handler_state :: MCPHandlerState
     -- ^ Current handler state for this session
+    , mcp_current_user :: Maybe MCPHandlerUser
+    -- ^ Authenticated user for the request currently being processed.  Set
+    -- per request by the HTTP JWT transport before each handler runs; always
+    -- 'Nothing' under stdio and 'simpleHttpApp'.  Prefer reading this via
+    -- 'getCurrentUser' rather than touching the field directly.
     , mcp_handler_init :: Maybe (MCPHandlerUser -> MCPHandlerState -> IO MCPHandlerState)
     -- ^ Initialize the handler state on server initialization
     , mcp_handler_finalize :: Maybe (MCPHandlerState -> IO MCPHandlerState)

--- a/mcp-server/src/MCP/Server/Common.hs
+++ b/mcp-server/src/MCP/Server/Common.hs
@@ -310,7 +310,7 @@ processed.
 
 This reflects the @servant-auth@ result attached to the in-flight HTTP request
 (JWT transport) and is set per request before each handler runs.  It is the
-recommended way to derive identity inside a handler — unlike the one-shot
+recommended way to derive identity inside a handler, unlike the one-shot
 'mcp_handler_init' hook, which only fires on the first @initialize@ call to
 the server-process-wide singleton state and is unsafe for multi-tenant
 deployments.
@@ -345,9 +345,10 @@ data MCPServerState = MCPServerState
     -- ^ Current handler state for this session
     , mcp_current_user :: Maybe MCPHandlerUser
     -- ^ Authenticated user for the request currently being processed.  Set
-    -- per request by the HTTP JWT transport before each handler runs; always
-    -- 'Nothing' under stdio and 'simpleHttpApp'.  Prefer reading this via
-    -- 'getCurrentUser' rather than touching the field directly.
+    -- per request by the HTTP JWT transport before each handler runs and
+    -- cleared afterward; always 'Nothing' under stdio and 'simpleHttpApp'.
+    -- Prefer reading this via 'getCurrentUser' rather than touching the
+    -- field directly.
     , mcp_handler_init :: Maybe (MCPHandlerUser -> MCPHandlerState -> IO MCPHandlerState)
     -- ^ Initialize the handler state on server initialization
     , mcp_handler_finalize :: Maybe (MCPHandlerState -> IO MCPHandlerState)

--- a/mcp-server/src/MCP/Server/HTTP/Internal.hs
+++ b/mcp-server/src/MCP/Server/HTTP/Internal.hs
@@ -34,7 +34,6 @@ import Data.ByteString.Lazy.Char8 qualified as BSL
 import Data.IntMap qualified as IM
 import Data.Text qualified as T
 import Data.Text.Encoding (encodeUtf8)
-import Data.Tuple (swap)
 import MCP.Server.Common
 import Network.HTTP.Media ((//))
 import Servant
@@ -148,8 +147,16 @@ handleMCPRequestCore state_var mb_user request_value =
                                                 return cur_st{mcp_handler_state = h_st'}
                     Nothing -> return ()
 
-                -- Process the request routing to the appropriate handler
-                res <- liftIO $ modifyMVar state_var $ fmap swap <$> runStateT (processMethod server_initialized method params)
+                -- Process the request routing to the appropriate handler.
+                -- Set 'mcp_current_user' to the request's authenticated user
+                -- (if any) inside the same atomic block that runs the
+                -- handler, so concurrent requests cannot observe each
+                -- other's identities through the shared MVar.  Handlers
+                -- read this via 'getCurrentUser'.
+                res <- liftIO $ modifyMVar state_var $ \cur_st -> do
+                    let cur_st_with_user = cur_st{mcp_current_user = mb_user}
+                    (r, final_st) <- runStateT (processMethod server_initialized method params) cur_st_with_user
+                    pure (final_st, r)
 
                 -- Log the response if debug level
                 cur_log_level <- liftIO $ mcp_log_level <$> readMVar state_var

--- a/mcp-server/src/MCP/Server/HTTP/Internal.hs
+++ b/mcp-server/src/MCP/Server/HTTP/Internal.hs
@@ -148,15 +148,11 @@ handleMCPRequestCore state_var mb_user request_value =
                     Nothing -> return ()
 
                 -- Process the request routing to the appropriate handler.
-                -- Set 'mcp_current_user' to the request's authenticated user
-                -- (if any) inside the same atomic block that runs the
-                -- handler, so concurrent requests cannot observe each
-                -- other's identities through the shared MVar.  Handlers
-                -- read this via 'getCurrentUser'.
-                res <- liftIO $ modifyMVar state_var $ \cur_st -> do
-                    let cur_st_with_user = cur_st{mcp_current_user = mb_user}
-                    (r, final_st) <- runStateT (processMethod server_initialized method params) cur_st_with_user
-                    pure (final_st, r)
+                -- Set mcp_current_user while the handler runs, then clear it
+                -- before releasing the shared state. Handlers read this via
+                -- getCurrentUser.
+                res <- liftIO $ modifyMVar state_var $
+                    runWithCurrentUser (processMethod server_initialized method params)
 
                 -- Log the response if debug level
                 cur_log_level <- liftIO $ mcp_log_level <$> readMVar state_var
@@ -221,13 +217,12 @@ handleMCPRequestCore state_var mb_user request_value =
                     Yield msg $
                         Effect $ do
                             ci_resp <- liftIO $ takeMVar mvar
-                            cur_st <- liftIO $ readMVar state_var
-                            (result, cur_st') <-
+                            result <-
                                 liftIO $
-                                    flip runStateT cur_st $
-                                        runExceptT $
-                                            ci_cont ci_resp
-                            liftIO $ modifyMVar_ state_var $ \_ -> return cur_st'
+                                    modifyMVar state_var $
+                                        runWithCurrentUser $
+                                            runExceptT $
+                                                ci_cont ci_resp
                             case result of
                                 Left err -> do
                                     return $ Source.Error $ T.unpack err
@@ -238,3 +233,9 @@ handleMCPRequestCore state_var mb_user request_value =
                     flip Yield Stop $
                         ResponseMessage $
                             JSONRPCResponse rPC_VERSION req_id (recurReplaceMeta $ toJSON response)
+
+    runWithCurrentUser :: StateT MCPServerState IO a -> MCPServerState -> IO (MCPServerState, a)
+    runWithCurrentUser action cur_st = do
+        let cur_st_with_user = cur_st{mcp_current_user = mb_user}
+        (result, final_st) <- runStateT action cur_st_with_user
+        pure (final_st{mcp_current_user = Nothing}, result)

--- a/mcp-server/test/MCP/Integration.hs
+++ b/mcp-server/test/MCP/Integration.hs
@@ -151,7 +151,7 @@ endpointsSpec = describe "Endpoint Health Check" $ do
     it "handles list/tools request successfully" $ do
         withInitializedServer $ \headers -> do
             let req_id = 2
-            let expected_tools = ["addition-tool", "constant-msg-tool"]
+            let expected_tools = ["addition-tool", "constant-msg-tool", "current-user-tool"]
             let list_tool_req = toJSON $ createListToolsRequest req_id
             -- the client sends the list tools request
             resp_list_tool <- mcpPostRequest headers list_tool_req
@@ -178,6 +178,17 @@ endpointsSpec = describe "Endpoint Health Check" $ do
             resp_call2 <- mcpPostRequest headers call_req2
             withValidJSONRPCResponse resp_call2 req_id2 $
                 validateToolCallResponse (toJSON ("Hello, World!" :: Text))
+
+    it "uses the authenticated user from each request" $ do
+        withInitializedServer $ \_headers -> do
+            withAuthenticatedRequestForSession "second-user-id" $ \headers -> do
+                let req_id = 11
+                let call_req =
+                        toJSON $
+                            createCallToolRequest req_id "current-user-tool" []
+                resp_call <- mcpPostRequest headers call_req
+                withValidJSONRPCResponse resp_call req_id $
+                    validateToolCallResponse (toJSON ("second-user-id" :: Text))
 
     it "handles prompt/list requests successfully" $ do
         withInitializedServer $ \headers -> do

--- a/mcp-server/test/MCP/SimpleHTTPIntegration.hs
+++ b/mcp-server/test/MCP/SimpleHTTPIntegration.hs
@@ -78,6 +78,7 @@ createSimpleHTTPTestState = do
         MCPServerState
             { mcp_server_initialized = False
             , mcp_handler_state = initializeTestState
+            , mcp_current_user = Nothing
             , mcp_handler_init = Nothing -- no user type in SimpleHTTP
             , mcp_handler_finalize = mb_handler_finalize
             , mcp_client_capabilities = Nothing

--- a/mcp-server/test/MCP/StdioIntegration.hs
+++ b/mcp-server/test/MCP/StdioIntegration.hs
@@ -67,6 +67,7 @@ createStdioServerState =
     MCPServerState
         { mcp_server_initialized = False
         , mcp_handler_state = initializeTestState
+        , mcp_current_user = Nothing
         , mcp_handler_init = Nothing -- No user in stdio mode
         , mcp_handler_finalize = mb_handler_finalize
         , mcp_client_capabilities = Nothing
@@ -192,7 +193,7 @@ toolSpec = describe "Tools" $ do
             sendMsg h_write (toJSON $ createListToolsRequest 2)
             (_, ListToolsResult{tools = ts}) <- recvTypedResponse h_read
             let tool_names = fmap (\Tool{name = n} -> n) ts
-            tool_names `shouldMatchList` ["addition-tool", "constant-msg-tool"]
+            tool_names `shouldMatchList` ["addition-tool", "constant-msg-tool", "current-user-tool"]
 
     it "calls the addition tool" $ do
         withStdioServer $ \(h_read, h_write) -> do

--- a/mcp-server/test/MCP/TestServer.hs
+++ b/mcp-server/test/MCP/TestServer.hs
@@ -184,6 +184,16 @@ processHandlers =
                 let ctx_result =
                         TextBlock $ TextContent "text" ("This is a constant message: " <> t_result) Nothing Nothing
                 return $ ProcessSuccess (CallToolResult [ctx_result] (Just result_value) Nothing Nothing)
+            "current-user-tool" -> do
+                mb_user <- getCurrentUser
+                case mb_user of
+                    Just user -> do
+                        let t_result = userId user
+                        let result_value = Map.fromList [("result", toJSON t_result)]
+                        let ctx_result =
+                                TextBlock $ TextContent "text" ("The current user is: " <> t_result) Nothing Nothing
+                        return $ ProcessSuccess (CallToolResult [ctx_result] (Just result_value) Nothing Nothing)
+                    Nothing -> return $ ProcessRPCError 401 "No authenticated user"
             _ -> return $ ProcessRPCError 404 "Tool not found"
 
     -- Example list prompts handler
@@ -331,6 +341,26 @@ availableTools =
         , annotations = Nothing
         , _meta = Nothing
         }
+    , Tool
+        { name = "current-user-tool"
+        , title = Just "Current User Tool"
+        , description = Just "Returns the authenticated request user"
+        , inputSchema =
+            InputSchema
+                { schemaType = "object"
+                , properties = Nothing
+                , required = Nothing
+                }
+        , outputSchema =
+            Just $
+                InputSchema
+                    { schemaType = "object"
+                    , properties = Just (Map.fromList [("result", object ["type" .= ("string" :: Text)])])
+                    , required = Just ["result"]
+                    }
+        , annotations = Nothing
+        , _meta = Nothing
+        }
     ]
 
 -- ** Available Prompts
@@ -455,6 +485,7 @@ createTestServerState = do
         MCPServerState
             { mcp_server_initialized = False
             , mcp_handler_state = initializeTestState
+            , mcp_current_user = Nothing
             , mcp_handler_init = mb_handler_init
             , mcp_handler_finalize = mb_handler_finalize
             , mcp_client_capabilities = Nothing


### PR DESCRIPTION
## Summary

This fixes a JWT HTTP transport identity bug where `mcp_handler_init` only ran for the first `initialize` request against the process-wide `MCPServerState`, causing later authenticated HTTP requests to run handlers with state initialized for the first user.

The first commit is the supplied patch, credited to Kris Nuttycombe. Follow-up commits keep that patch separate and add hardening/tests:

- clears `mcp_current_user` after each handler run
- runs `ProcessClientInput` continuations with the originating request user
- updates test state constructors for the new field
- adds a regression test that initializes as one user and verifies a later request sees its own JWT identity

This also fixes the Docker CI build so it uses the committed `cabal.project.freeze` dependency plan and installs `pkg-config`, which the frozen `zlib` flags require.

## Credit

Original patch provided by Kris Nuttycombe (@nuttycom).

## Validation

- `cabal test all`
- `mcp-types`: 101 examples, 0 failures
- `mcp`: 82 examples, 0 failures
- Docker CI passed on GitHub Actions run `26519296957`
